### PR TITLE
Adding protection when accessing order_id

### DIFF
--- a/tick_taker.py
+++ b/tick_taker.py
@@ -1,5 +1,3 @@
-import sys
-sys.path.append('../alpaca-trade-api-python')
 import argparse
 import pandas as pd
 import numpy as np
@@ -98,6 +96,9 @@ class Position():
                     self.update_pending_sell_shares(old_amount - new_amount)
                     self.update_total_shares(old_amount - new_amount)
                 self.orders_filled_amount[order_id] = new_amount
+        else:
+            logger.console(
+                f'Order ID: {order_id} not present on current orders.')
 
     def remove_pending_order(self, order_id, side):
         old_amount = self.orders_filled_amount.get(order_id)
@@ -107,6 +108,9 @@ class Position():
             else:
                 self.update_pending_sell_shares(old_amount - 100)
             del self.orders_filled_amount[order_id]
+        else:
+            logger.console(
+                f'Order ID: {order_id} not present on current orders.')
 
     def update_total_shares(self, quantity):
         self.total_shares += quantity

--- a/tick_taker.py
+++ b/tick_taker.py
@@ -88,15 +88,16 @@ class Position():
         self.pending_sell_shares += quantity
 
     def update_filled_amount(self, order_id, new_amount, side):
-        old_amount = self.orders_filled_amount[order_id]
-        if new_amount > old_amount:
-            if side == 'buy':
-                self.update_pending_buy_shares(old_amount - new_amount)
-                self.update_total_shares(new_amount - old_amount)
-            else:
-                self.update_pending_sell_shares(old_amount - new_amount)
-                self.update_total_shares(old_amount - new_amount)
-            self.orders_filled_amount[order_id] = new_amount
+        old_amount = self.orders_filled_amount.get(order_id)
+        if old_amount:
+            if new_amount > old_amount:
+                if side == 'buy':
+                    self.update_pending_buy_shares(old_amount - new_amount)
+                    self.update_total_shares(new_amount - old_amount)
+                else:
+                    self.update_pending_sell_shares(old_amount - new_amount)
+                    self.update_total_shares(old_amount - new_amount)
+                self.orders_filled_amount[order_id] = new_amount
 
     def remove_pending_order(self, order_id, side):
         old_amount = self.orders_filled_amount.get(order_id)

--- a/tick_taker.py
+++ b/tick_taker.py
@@ -97,7 +97,7 @@ class Position():
                     self.update_total_shares(old_amount - new_amount)
                 self.orders_filled_amount[order_id] = new_amount
         else:
-            logger.console(
+            print(
                 f'Order ID: {order_id} not present on current orders.')
 
     def remove_pending_order(self, order_id, side):
@@ -109,7 +109,7 @@ class Position():
                 self.update_pending_sell_shares(old_amount - 100)
             del self.orders_filled_amount[order_id]
         else:
-            logger.console(
+            print(
                 f'Order ID: {order_id} not present on current orders.')
 
     def update_total_shares(self, quantity):

--- a/tick_taker.py
+++ b/tick_taker.py
@@ -1,3 +1,5 @@
+import sys
+sys.path.append('../alpaca-trade-api-python')
 import argparse
 import pandas as pd
 import numpy as np
@@ -97,12 +99,13 @@ class Position():
             self.orders_filled_amount[order_id] = new_amount
 
     def remove_pending_order(self, order_id, side):
-        old_amount = self.orders_filled_amount[order_id]
-        if side == 'buy':
-            self.update_pending_buy_shares(old_amount - 100)
-        else:
-            self.update_pending_sell_shares(old_amount - 100)
-        del self.orders_filled_amount[order_id]
+        old_amount = self.orders_filled_amount.get(order_id)
+        if old_amount:
+            if side == 'buy':
+                self.update_pending_buy_shares(old_amount - 100)
+            else:
+                self.update_pending_sell_shares(old_amount - 100)
+            del self.orders_filled_amount[order_id]
 
     def update_total_shares(self, quantity):
         self.total_shares += quantity


### PR DESCRIPTION
An order id reported back on on_trade_update is currently being sent to all websocket clients connecting from the same IP / credentials.

This enhancement will prevent exception generated by attempting to access a non existent key.